### PR TITLE
Add travis build configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: php
+
+php:
+  - 5.3
+  - 5.4
+  - 5.5
+
+script:
+  - phpize
+  - ./configure --with-libev
+  - make
+  - make install


### PR DESCRIPTION
Hello,

This introduces a travis build environment that shows that compilation fails in some environment (see output of https://travis-ci.org/romainneutron/php-libev/jobs/5485063 for example). It addresses issue #5

This travis build script could be improved by enabling the extension and execute basic stuff.
